### PR TITLE
PHP: Materialze `PHPSTAN_SCANDIRS` even if `phpstan.neon` is missing

### DIFF
--- a/.github/actions/phpstan-adjust-scandirs/action.yml
+++ b/.github/actions/phpstan-adjust-scandirs/action.yml
@@ -59,6 +59,19 @@ runs:
           printf "${NC}\n"
         }
 
+        set_env() {
+          local key="$1"
+          local value="$2"
+          echo "${key}=${value}"
+          echo "${key}=${value}" >> $GITHUB_ENV
+        }
+
+        if [ ! -f phpstan.neon ]; then
+          # Mark phpstan.neon config as generated (missing level and scan paths)
+          # so that the `php-sa` workflow supplies these parameters through CLI arguments.
+          set_env PHPSTAN_CONFIG_GENERATED 1
+        fi
+
         log_cmd phpstan-adjust-scandirs.php \
           --config=phpstan.neon --scan="${PHPSTAN_SCANDIRS}" --exclude="${PHPSTAN_EXCLUDE}" --inplace
         ./phpstan-adjust-scandirs/phpstan-adjust-scandirs/phpstan-adjust-scandirs.php \

--- a/.github/workflows/php-sa.yml
+++ b/.github/workflows/php-sa.yml
@@ -50,7 +50,7 @@ jobs:
           php-tools: phpstan
 
       - name: Adjust PHPStan scanDirectories
-        if: ${{ hashFiles(format('{0}/{1}', inputs.working-directory, 'phpstan.neon')) != '' && env.PHPSTAN_SCANDIRS != ''}}
+        if: ${{ env.PHPSTAN_SCANDIRS != ''}}
         uses: Icinga/github-actions/.github/actions/phpstan-adjust-scandirs@main
         with:
           working-directory: ${{ inputs.working-directory }}
@@ -71,16 +71,27 @@ jobs:
             printf "${NC}\n"
           }
 
-          if [ -f "${{ inputs.working-directory }}/phpstan.neon" ]; then
-            args=(--configuration "${{ inputs.working-directory }}/phpstan.neon")
-          else
-            # Find all direct child directories, excluding vendor and hidden dirs
-            dirs=($(find "${{ inputs.working-directory }}" -mindepth 1 -maxdepth 1 \
-              -type d \
-              -not -path "${{ inputs.working-directory }}/vendor" \
-              -not -path "${{ inputs.working-directory }}/.*"))
+          args=()
 
-            # Find all direct child PHP files
+          configuration=""
+          if [ -f "${{ inputs.working-directory }}/phpstan.neon" ]; then
+            configuration="${{ inputs.working-directory }}/phpstan.neon"
+          fi;
+
+          # Supply level and scan paths as CLI arguments if PHPStan config is missing or generated.
+          if [ -z "$configuration" ] || [ -n "$PHPSTAN_CONFIG_GENERATED" ]; then
+            # Find all direct child directories containing PHP files; exclude vendor dirs.
+            php_dirs=()
+            while IFS= read -r -d '' dir; do
+              if [[ -n $(find "$dir" -type f -name "*.php" -print -quit) ]]; then
+                php_dirs+=("$dir")
+              fi
+            done < <(find "${{ inputs.working-directory }}" -mindepth 1 -maxdepth 1 \
+              -type d \
+              -not -name "vendor" \
+              -print0)
+
+            # Find all direct child PHP files.
             php_files=($(find "${{ inputs.working-directory }}" -mindepth 1 -maxdepth 1 \
               -type f -name '*.php'))
 
@@ -92,11 +103,22 @@ jobs:
               composer_vendor="$(composer -d ${{ inputs.working-directory }} config vendor-dir)"
               autoload="${{ inputs.working-directory }}/${composer_vendor}/autoload.php"
             fi
+
             args=(--level=6)
             if [ -n "$autoload" ]; then
               args+=(-a "$autoload")
             fi
-            args+=("${dirs[@]}" "${php_files[@]}")
+            args+=("${php_dirs[@]}" "${php_files[@]}")
+          fi
+
+          if [ -n "$configuration" ]; then
+            array_unshift() {
+              local -n arr="$1"
+              shift
+              arr=("$@" "${arr[@]}")
+            }
+
+            array_unshift args --configuration "$configuration"
           fi
 
           log_cmd phpstan analyse "${args[@]}"


### PR DESCRIPTION
Previously, the `phpstan-adjust-scandirs` action and `php-sa` workflow required a `phpstan.neon` to be present for scan directories to be materialized and used.

- `phpstan-adjust-scandirs`: Sets `PHPSTAN_CONFIG_GENERATED=1` when no `phpstan.neon` is found, signaling that level and scan paths must be supplied via CLI.
- `php-sa`: Removes the `hashFiles(phpstan.neon)` guard from the "Adjust scanDirectories" step so it runs whenever `PHPSTAN_SCANDIRS` is set. Separates config detection from argument building; supplies `--level`, scan directories, and autoload via CLI when config is absent or generated. Filters discovered directories to only those containing PHP files.
- `phpstan-adjust-scandirs.php`: Treats a missing config file as an empty config instead of an error, allowing the script to generate a fresh `phpstan.neon` from the provided scan directories alone.